### PR TITLE
Add the wireless service UUID to the SDP record

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+libnymea-networkmanager (0.5.0) UNRELEASED; urgency=medium
+
+
+ -- Michael Zanetti <michael.zanetti@nymea.io>  Sat, 27 Mar 2021 00:32:57 +0100
+
 libnymea-networkmanager (0.4.2) xenial; urgency=medium
 
   [ Michael Zanetti ]

--- a/libnymea-networkmanager/bluetooth/bluetoothserver.h
+++ b/libnymea-networkmanager/bluetooth/bluetoothserver.h
@@ -60,7 +60,7 @@ public:
     ~BluetoothServer();
 
     QString advertiseName() const;
-    void setAdvertiseName(const QString &advertiseName);
+    void setAdvertiseName(const QString &advertiseName, bool forceFullName = false);
 
     // Information for the device info service
     QString modelName() const;
@@ -80,6 +80,7 @@ public:
 
 private:
     QString m_advertiseName;
+    bool m_forceFullName = false;
 
     QString m_modelName;
     QString m_softwareVersion;


### PR DESCRIPTION
This allows more reliable client side filtering, however comes with
the downside of leaving only 8 characters of space for the device name.