### PR TITLE
bluetooth: use qt5 connect syntax

### DIFF
--- a/libnymea-networkmanager/bluetooth/bluetoothserver.cpp
+++ b/libnymea-networkmanager/bluetooth/bluetoothserver.cpp
@@ -452,7 +452,8 @@ void BluetoothServer::start()
     connect(m_controller, &QLowEnergyController::stateChanged, this, &BluetoothServer::onControllerStateChanged);
     connect(m_controller, &QLowEnergyController::connected, this, &BluetoothServer::onConnected);
     connect(m_controller, &QLowEnergyController::disconnected, this, &BluetoothServer::onDisconnected);
-    connect(m_controller, SIGNAL(error(QLowEnergyController::Error)), this, SLOT(onError(QLowEnergyController::Error)));
+    connect(m_controller, static_cast<void(QLowEnergyController::*)(QLowEnergyController::Error)>
+                         (&QLowEnergyController::error), this, &BluetoothServer::onError);
 
     // Note: https://www.bluetooth.com/specifications/gatt/services
     m_deviceInfoService = m_controller->addService(deviceInformationServiceData(), m_controller);

--- a/libnymea-networkmanager/bluetooth/networkservice.cpp
+++ b/libnymea-networkmanager/bluetooth/networkservice.cpp
@@ -50,11 +50,12 @@ NetworkService::NetworkService(QLowEnergyService *service, NetworkManager *netwo
     qCDebug(dcNetworkManagerBluetoothServer()) << "Create NetworkService.";
 
     // Service
-    connect(m_service, SIGNAL(characteristicChanged(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicChanged(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(characteristicRead(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicChanged(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(characteristicWritten(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicWritten(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(descriptorWritten(QLowEnergyDescriptor, QByteArray)), this, SLOT(descriptorWritten(QLowEnergyDescriptor, QByteArray)));
-    connect(m_service, SIGNAL(error(QLowEnergyService::ServiceError)), this, SLOT(serviceError(QLowEnergyService::ServiceError)));
+    connect(m_service, &QLowEnergyService::characteristicChanged, this, &NetworkService::characteristicChanged);
+    connect(m_service, &QLowEnergyService::characteristicRead, this, &NetworkService::characteristicRead);
+    connect(m_service, &QLowEnergyService::characteristicWritten, this, &NetworkService::characteristicWritten);
+    connect(m_service, &QLowEnergyService::descriptorWritten, this, &NetworkService::descriptorWritten);
+    connect(m_service, static_cast<void(QLowEnergyService::*)(QLowEnergyService::ServiceError)>
+                      (&QLowEnergyService::error), this, &NetworkService::serviceError);
 
     // NetworkManager
     connect(m_networkManager, &NetworkManager::stateChanged, this, &NetworkService::onNetworkManagerStateChanged);

--- a/libnymea-networkmanager/bluetooth/wirelessservice.cpp
+++ b/libnymea-networkmanager/bluetooth/wirelessservice.cpp
@@ -52,11 +52,12 @@ WirelessService::WirelessService(QLowEnergyService *service, NetworkManager *net
     qCDebug(dcNetworkManagerBluetoothServer()) << "Create WirelessService.";
 
     // Service
-    connect(m_service, SIGNAL(characteristicChanged(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicChanged(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(characteristicRead(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicChanged(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(characteristicWritten(QLowEnergyCharacteristic, QByteArray)), this, SLOT(characteristicWritten(QLowEnergyCharacteristic, QByteArray)));
-    connect(m_service, SIGNAL(descriptorWritten(QLowEnergyDescriptor, QByteArray)), this, SLOT(descriptorWritten(QLowEnergyDescriptor, QByteArray)));
-    connect(m_service, SIGNAL(error(QLowEnergyService::ServiceError)), this, SLOT(serviceError(QLowEnergyService::ServiceError)));
+    connect(m_service, &QLowEnergyService::characteristicChanged, this, &WirelessService::characteristicChanged);
+    connect(m_service, &QLowEnergyService::characteristicRead, this, &WirelessService::characteristicRead);
+    connect(m_service, &QLowEnergyService::characteristicWritten, this, &WirelessService::characteristicWritten);
+    connect(m_service, &QLowEnergyService::descriptorWritten, this, &WirelessService::descriptorWritten);
+    connect(m_service, static_cast<void(QLowEnergyService::*)(QLowEnergyService::ServiceError)>
+                      (&QLowEnergyService::error), this, &WirelessService::serviceError);
 
     // Get the wireless network device if there is any
     if (!m_networkManager->wirelessAvailable()) {


### PR DESCRIPTION
The origin of the mixed use is probably due to existing overloaded methods of error() The solution is here:
https://stackoverflow.com/questions/16794695/connecting-overloaded-signals-and-slots-in-qt-5

This PR also fixes two wrong connections: the `characteristicRead` was wrongly connected to `characteristicChanged` in both services.
